### PR TITLE
Refactoring getQueryParams in order to support array parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.9.0 (2020-09-03)
+
+## Improvement
+
+- Refactoring `getQueryParams` in order to support array of parameters and providing a sample of usage [faustoonna]
+
 # 1.8.0 (2020-08-10)
 
 ## New feature

--- a/projects/traversal/package.json
+++ b/projects/traversal/package.json
@@ -1,6 +1,6 @@
 {
     "name": "angular-traversal",
-    "version": "1.8.0",
+    "version": "1.9.0",
     "license": "MIT",
     "author": {
         "name": "Eric Brehault",

--- a/projects/traversal/src/lib/traverser.ts
+++ b/projects/traversal/src/lib/traverser.ts
@@ -323,7 +323,7 @@ export class Traverser {
         };
     }
 
-    getQueryParams(): Observable<{ [key: string]: string }> {
+    getQueryParams<T = string>(): Observable<{ [key: string]: T }> {
         return this.target.pipe(
             take(1),
             map((target) => {
@@ -331,13 +331,20 @@ export class Traverser {
                 if (!queryParams) {
                     return {};
                 } else {
-                    return queryParams.keys().reduce((all: { [key: string]: string }, key) => {
-                        const value = queryParams.get(key);
-                        if (!!value) {
-                            all[key] = value;
-                        }
-                        return all;
-                    }, {});
+                    return queryParams
+                        .keys()
+                        .reduce((all: { [key: string]: T }, key) => {
+                            const value = queryParams.getAll(key);
+                            if (!value) {
+                                return all;
+                            }
+                            if (value.length > 1) {
+                                all[key] = value as unknown as T;
+                            } else {
+                                all[key] = value[0] as unknown as T;
+                            }
+                            return all;
+                        }, {});
                 }
             })
         );

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -21,6 +21,9 @@ export class AppComponent {
         traverser.addLazyView('lazyinfo', 'file', () =>
             import('./file-info-lazy/module').then((m) => m.FileInfoLazyModule)
         );
+        traverser.addLazyView('query-parameters', 'dir', () =>
+            import('./query-parameters/query-parameters.module').then((m) => m.QueryParametersModule),
+        );
         traverser.addView('view', 'dir', FolderComponent);
         traverser.addLazyTile('details', 'file', () => import('./file/module').then((m) => m.FileDetailsModule));
         traverser.addTile('details', 'dir', FolderDetailsComponent);

--- a/src/app/folder/folder.component.html
+++ b/src/app/folder/folder.component.html
@@ -1,8 +1,13 @@
-<ul>
-    <li *ngFor="let entry of context">
-        <a [traverseTo]="entry.url">
-            {{ entry.name }}
-        </a>
-        <button (click)="openDetail(entry.url)">Details</button>
-    </li>
-</ul>
+<div>
+    <a [traverseTo]="path+'/@@query-parameters?param1=value1&param1=value2&param2=value3'">
+        List params
+    </a>
+    <ul>
+        <li *ngFor="let entry of context">
+            <a [traverseTo]="entry.url">
+                {{ entry.name }}
+            </a>
+            <button (click)="openDetail(entry.url)">Details</button>
+        </li>
+    </ul>
+</div>

--- a/src/app/folder/folder.component.ts
+++ b/src/app/folder/folder.component.ts
@@ -9,12 +9,14 @@ import { DetailService } from '../service';
 })
 export class FolderComponent implements OnInit {
     public context: any;
+    public path: string = '';
 
     constructor(private traverser: Traverser, private service: DetailService) {}
 
     ngOnInit() {
         this.traverser.target.subscribe((target) => {
             this.context = target.context;
+            this.path = target.contextPath;
         });
     }
 

--- a/src/app/query-parameters/query-parameters.component.html
+++ b/src/app/query-parameters/query-parameters.component.html
@@ -1,0 +1,8 @@
+<ul>
+    <li *ngFor="let paramKey of parameterKeys">
+        <strong>{{ paramKey }}</strong>
+        <small>
+            {{parameters[paramKey]}}
+        </small>
+    </li>
+</ul>

--- a/src/app/query-parameters/query-parameters.component.ts
+++ b/src/app/query-parameters/query-parameters.component.ts
@@ -1,0 +1,37 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Traverser } from '../../../projects/traversal/src/public-api';
+import { Subject, throwError } from 'rxjs';
+import { takeUntil, map } from 'rxjs/operators';
+
+@Component({
+    selector: 'app-query-parameters',
+    templateUrl: './query-parameters.component.html',
+    styleUrls: ['./query-parameters.component.css'],
+})
+export class QueryParametersComponent implements OnInit, OnDestroy {
+    context: any;
+    lock = false;
+    terminator: Subject<void> = new Subject();
+    parameters: { [key: string]: string | string [] } = {};
+    parameterKeys: string[] = [];
+
+    constructor(private traverser: Traverser) {}
+
+    ngOnInit() {
+        this.traverser
+            .getQueryParams()
+            .subscribe(data => {
+                console.log('Query parameters', data);
+                this.parameters = data;
+                this.parameterKeys = Object.keys(data);
+            });
+    }
+
+    toggleLock() {
+        this.lock = !this.lock;
+    }
+
+    ngOnDestroy() {
+        this.terminator.next();
+    }
+}

--- a/src/app/query-parameters/query-parameters.module.ts
+++ b/src/app/query-parameters/query-parameters.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ViewMapping } from '../../../projects/traversal/src/public-api';
+import { QueryParametersComponent } from './query-parameters.component';
+
+@NgModule({
+    imports: [CommonModule],
+    exports: [QueryParametersComponent],
+    declarations: [QueryParametersComponent],
+    providers: [],
+})
+export class QueryParametersModule {
+    static traverserViews: ViewMapping[] = [
+        { name: 'query-parameters', components: { dir: QueryParametersComponent } }
+    ];
+}


### PR DESCRIPTION
The current implementation is not handling properly URL array parameters, i.e:
``` http://myurl.com?param1=value1&param1=value2```
it will return 
```
{ param1: "value1" } 
rather than
{ param1: ["value1", "value2]  }
```
That's due to the method used to retrieve the map content by key used in getQueryParams reducer 
```const value = queryParams.get(key);```
which behave in a different way compared to the common `Map.get()`( https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/get)
`@angular/common/http/http.d.ts`
```
/**
     * Retrieves the first value for a parameter.
     * @param param The parameter name.
     * @returns The first value of the given parameter,
     * or `null` if the parameter is not present.
*/
    get(param: string): string | null;

```